### PR TITLE
Disable default features for bevy_defer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ bevy_log = "0.16.0"
 bevy_ecs = "0.16.0"
 bevy_tasks = "0.16.0"
 bevy_derive = "0.16.0"
-bevy_defer = "0.14.0"
+bevy_defer = { version = "0.14.0", default-features = false }
 hyper = { version = "1.1.0", features = ["server", "http1"] }
 async-io = "2.4.0"
 smol-hyper = { version = "0.1.1" }


### PR DESCRIPTION
I'm using this for a goofy little headless bevy project and noticed that this crate was still pulling in bevy rendering deps.
This tightens it up a bit so it shouldn't, no idea if you want this but it was useful for me.

Cheers for the crate!